### PR TITLE
unidecode search string (closes #165)

### DIFF
--- a/app/models/control_lists.py
+++ b/app/models/control_lists.py
@@ -160,7 +160,7 @@ class ControlLists(db.Model):
                 filters,
                 db.or_(
                     *(
-                        db.and_(*tuple(column_search_filter(AllowedLemma.label_uniform, search_string)))
+                        db.and_(*tuple(column_search_filter(AllowedLemma.label_uniform, unidecode.unidecode(search_string))))
                         for search_string in prepare_search_string(kw)
                     )
                 )


### PR DESCRIPTION
the search string is compared against the lemma's unidecoded label
s.t. for "Balesgués" and "Balesgues" to return the same results the
search string must be unidecoded too