### PR TITLE
show detailed error message when duplicates are in list of allowed

### DIFF
--- a/app/control_lists/views.py
+++ b/app/control_lists/views.py
@@ -9,6 +9,7 @@ from werkzeug.exceptions import BadRequest, NotFound, Forbidden
 from app.main.views.utils import render_template_with_nav_info
 from app.models import ControlLists, AllowedLemma, WordToken, User, PublicationStatus
 from app import db, email
+from ..utils import PyrrhaError
 from ..utils.forms import strip_or_none
 from ..utils.tsv import StringDictReader
 from ..utils.response import format_api_like_reply
@@ -184,11 +185,13 @@ def edit(cl_id, allowed_type, control_list):
             ]
         else:
             allowed_values = list(StringDictReader(allowed_values))
-        success = control_list.update_allowed_values(allowed_type, allowed_values)
-        if success:
+        try:
+            control_list.update_allowed_values(allowed_type, allowed_values)
             flash("Control List Updated", category="success")
-        else:
-            flash("An error occured", category="error")
+        except PyrrhaError as exception:
+            flash("A Pyrrha error occurred: {}".format(exception), category="error")
+        except:
+            flash("An unknown error occurred", category="error")
 
     values = control_list.get_allowed_values(allowed_type=allowed_type, order_by="id")
     if allowed_type == "lemma":

--- a/app/models/control_lists.py
+++ b/app/models/control_lists.py
@@ -15,6 +15,7 @@ from sqlalchemy import literal, case
 from werkzeug.exceptions import BadRequest
 # APP Logic
 from .. import db
+from ..utils import PyrrhaError
 from ..utils.forms import prepare_search_string, column_search_filter, read_input_POS, read_input_morph, \
     read_input_lemma
 # Models
@@ -216,8 +217,7 @@ class ControlLists(db.Model):
         except Exception as E:
             print(E)
             db.session.rollback()
-            return False
-        return True
+            raise
 
     def has_list(self, allowed_type):
         """ Check if the Control List has the specific allowed_type
@@ -309,7 +309,7 @@ class AllowedLemma(db.Model):
         :param _commit: Force commit (Default: false)
         """
         if len(allowed_values) != len(set(allowed_values)):
-            raise Exception("Following values are duplicated: " + ", ".join(
+            raise PyrrhaError("Following values are duplicated: " + ", ".join(
                 [
                     lemma
                     for lemma, cnt in Counter(allowed_values).items()

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,3 +1,8 @@
 from .pagination import int_or
 from .tsv import StringDictReader
 from .forms import string_to_none
+
+
+class PyrrhaError(Exception):
+    """Raised when errors specific to this application occur."""
+    pass


### PR DESCRIPTION
lemmas (closes #175)

show detailed message containing duplicates in user interface, but
hide possibly more cryptic exceptions (database connection errors, ...)
from user