### PR TITLE
Update index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ Pyrrha
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2325427.svg)](https://doi.org/10.5281/zenodo.2325427)
 
-This documentation is provided for https://dh.chartes.psl.eu/pyrrha . If you are just wanting to test things out and do not care about data loss at all, you can also test the dev version : https://dev.chartes.psl.eu/pyrrha .
+This documentation is provided for [https://dh.chartes.psl.eu/pyrrha](https://dh.chartes.psl.eu/pyrrha) . If you are just wanting to test things out and do not care about data loss at all, you can also test the dev version : [https://dev.chartes.psl.eu/pyrrha](https://dev.chartes.psl.eu/pyrrha).
 
 Pyrrha is a simple Python Flask WebApp to fasten the post-correction
 of lemmatized and morpho-syntactic tagged corpora. The project has been funded and is maintained by the funds of the [Ecole Nationale des Chartes](https://www.chartes.psl.eu).
@@ -15,4 +15,4 @@ This web application and its maintenance is done by Julien Pilla (@MrGecko) and 
 This software is built as an addition to the tagger Pie by Enrique Manjavacas (@emanjavacas) and Mike Kestemont (@mikekestemont) [![DOI](https://zenodo.org/badge/131014015.svg)](https://zenodo.org/badge/latestdoi/131014015)
 
 ## Demo
-![Pandora Post-Correction Editor](../demo.gif)
+![Pandora Post-Correction Editor](https://raw.githubusercontent.com/hipster-philology/pyrrha/dev/demo.gif)


### PR DESCRIPTION
Make links clickable in the docs. No one reads everything anymore, it took a colleague to tell me there's an online version for me to come back and see that there were links hidden in plain text. 

Gif link was also broken in the [docs](https://pyrrha.readthedocs.io/en/latest/).