### PR TITLE
users w/o editing permissions should not be shown 'Add new lemma' button (closes #149)

### DIFF
--- a/app/templates/control_lists/read_lemma.html
+++ b/app/templates/control_lists/read_lemma.html
@@ -7,6 +7,7 @@
 <h1>{{control_list.name}}</h1>
 <h2>Control List for Lemmas</h2>
 
+{% if can_edit %}
 <div class="form" style="padding-bottom: 10px;">
   <form id="lemma_update" class="form" style="margin-top:1em;" method="POST" action="{{url_for('control_lists_bp.lemma_list', control_list_id=control_list.id)}}">
     <div class="form-group row">
@@ -24,6 +25,7 @@
     </div>
   </form>
 </div>
+{% endif %}
 
 <div class="row">
   <div class="col-sm-12">


### PR DESCRIPTION
do not show corresponding part of view to users without these permissions

tested in dev interface

* user w/o editing permissions (not admin, not owner) cannot see button
* owner (not admin) can see button
* admin can see button