### PR TITLE
added back end / front end checks and tests for token field length (closes #168)

### DIFF
--- a/app/main/views/corpus.py
+++ b/app/main/views/corpus.py
@@ -7,6 +7,7 @@ from sqlalchemy import func, distinct, text
 from app import db
 from app.models import CorpusUser, ControlLists, WordToken, ChangeRecord, Bookmark, Favorite
 from .utils import render_template_with_nav_info
+from app.utils import ValidationError
 from app.utils.forms import create_input_format_convertion, read_input_tokens
 from .. import main
 from ...utils.forms import strip_or_none
@@ -98,6 +99,10 @@ def corpus_new():
             except NoTokensInput:
                 db.session.rollback()
                 flash("You did not input any text.", category="error")
+                return error()
+            except ValidationError as exception:
+                db.session.rollback()
+                flash(exception, category="error")
                 return error()
             except Exception as e:
                 db.session.rollback()

--- a/app/models/corpus.py
+++ b/app/models/corpus.py
@@ -12,6 +12,7 @@ from werkzeug.exceptions import BadRequest
 from flask import url_for
 # Application imports
 from .. import db
+from ..utils import validate_length
 from ..utils.forms import strip_or_none
 from ..utils.tsv import TSV_CONFIG
 from ..errors import MissingTokenColumnValue, NoTokensInput
@@ -870,6 +871,8 @@ class WordToken(db.Model):
                 corpus=corpus_id,
                 order_id=i+1  # Asked by JB Camps...
             )
+            for k in ("form",):
+                validate_length(k, wt[k], {"form": 64})
             tokens.append(wt)
 
         db.session.bulk_insert_mappings(WordToken, tokens)

--- a/app/templates/macros/validate_length.html
+++ b/app/templates/macros/validate_length.html
@@ -2,13 +2,13 @@
     <script type="text/javascript">
         document.getElementById("form").addEventListener("submit", (evt => validateLength(evt, "{{textArea}}", {{index}}, {{length}})));
 
-        function insertValidateLengthError(validatedField, fieldValue, length, siblingId) {
+        function insertValidateLengthError(validatedField, fieldValue, length, siblingId, index) {
             // create unique ID for each error message
             validateLengthErrorId = `validateLengthError${Date.now()}`;
             var validateLengthError = document.createElement("div");
             validateLengthError.id = validateLengthErrorId;
             validateLengthError.className = "alert alert-danger mt-3 mb-3";
-            validateLengthError.textContent = `column '${validatedField}': '${fieldValue}' is too long (maximum ${length} characters)`;
+            validateLengthError.textContent = `ln. ${index}, column '${validatedField}': '${fieldValue}' is too long (maximum ${length} characters)`;
             if (!siblingId) {
                 document.getElementById("tokensLabel").insertBefore(validateLengthError, parent.firstChild);
             }
@@ -38,7 +38,7 @@
                 for (let i=1; i < fields.length; i++){
                     fieldValue = fields[i][index]
                     if (fieldValue.length > length){
-                        siblingId = insertValidateLengthError(validatedField, fieldValue, length, siblingId);
+                        siblingId = insertValidateLengthError(validatedField, fieldValue, length, siblingId, i+1);
                         evt.preventDefault();
                         // highlight first erroneous line
                         if (!highlighted) {

--- a/app/templates/macros/validate_length.html
+++ b/app/templates/macros/validate_length.html
@@ -1,29 +1,55 @@
 {% macro validateLength(textArea, index, length) %}
     <script type="text/javascript">
-    document.getElementById("form").addEventListener("submit", (evt => validateLength(evt, "{{textArea}}", {{index}}, {{length}})));
-    function validateLength(evt, textArea, lengths){
-        textAreaElement = document.getElementById(textArea)
-        var text = textAreaElement.value;
-        lines = text.split(/\r\n|\n\r|\r|\n/);
-        fields = lines.map((x) => x.split(/\t+/));
-        for (const index in lengths) {
-            length = lengths[index];
-            var validatedField = fields[0][index];
-            for (let i=1; i < fields.length; i++){
-                fieldValue = fields[i][index]
-                if (fieldValue.length > length){
-                    evt.preventDefault();
-                    startPos = text.search(new RegExp(fieldValue));
-                    textAreaElement.setSelectionRange(startPos, startPos + fieldValue.length)
-                    textAreaElement.focus();
-                    var div = document.createElement("div");
-                    div.className = "alert alert-danger mt-3 mb-3";
-                    div.textContent = `column '${validatedField}': '${fieldValue}' is too long (maximum ${length} characters)`;
-                    var formElement = document.getElementById("form");
-                    formElement.insertBefore(div, formElement.firstChild);
+        document.getElementById("form").addEventListener("submit", (evt => validateLength(evt, "{{textArea}}", {{index}}, {{length}})));
+
+        function insertValidateLengthError(validatedField, fieldValue, length, siblingId) {
+            // create unique ID for each error message
+            validateLengthErrorId = `validateLengthError${Date.now()}`;
+            var validateLengthError = document.createElement("div");
+            validateLengthError.id = validateLengthErrorId;
+            validateLengthError.className = "alert alert-danger mt-3 mb-3";
+            validateLengthError.textContent = `column '${validatedField}': '${fieldValue}' is too long (maximum ${length} characters)`;
+            if (!siblingId) {
+                document.getElementById("tokensLabel").insertBefore(validateLengthError, parent.firstChild);
+            }
+            else {
+                document.getElementById(siblingId).after(validateLengthError);
+            }
+            return validateLengthErrorId;
+        };
+
+        function clearError(tokensLabel){
+            newTokensLabel = tokensLabel.cloneNode(false);
+            tokensLabel.parentNode.replaceChild(newTokensLabel, tokensLabel)
+        };
+
+        function validateLength(evt, textAreaId, lengths){
+            // clear previous error messages
+            clearError(document.getElementById("tokensLabel"))
+            textArea = document.getElementById(textAreaId)
+            var text = textArea.value;
+            lines = text.split(/\r\n|\n\r|\r|\n/);
+            fields = lines.map((x) => x.split(/\t+/));
+            for (const index in lengths) {
+                length = lengths[index];
+                var validatedField = fields[0][index];
+                var siblingId = "";
+                var highlighted = false;
+                for (let i=1; i < fields.length; i++){
+                    fieldValue = fields[i][index]
+                    if (fieldValue.length > length){
+                        siblingId = insertValidateLengthError(validatedField, fieldValue, length, siblingId);
+                        evt.preventDefault();
+                        // highlight first erroneous line
+                        if (!highlighted) {
+                            startPos = text.search(new RegExp(fieldValue));
+                            textArea.setSelectionRange(startPos, startPos + fieldValue.length)
+                            textArea.focus();
+                            highlighted = true;
+                        };
+                    };
                 };
             };
         };
-    };
 </script>
 {% endmacro %}

--- a/app/templates/macros/validate_length.html
+++ b/app/templates/macros/validate_length.html
@@ -1,0 +1,29 @@
+{% macro validateLength(textArea, index, length) %}
+    <script type="text/javascript">
+    document.getElementById("form").addEventListener("submit", (evt => validateLength(evt, "{{textArea}}", {{index}}, {{length}})));
+    function validateLength(evt, textArea, lengths){
+        textAreaElement = document.getElementById(textArea)
+        var text = textAreaElement.value;
+        lines = text.split(/\r\n|\n\r|\r|\n/);
+        fields = lines.map((x) => x.split(/\t+/));
+        for (const index in lengths) {
+            length = lengths[index];
+            var validatedField = fields[0][index];
+            for (let i=1; i < fields.length; i++){
+                fieldValue = fields[i][index]
+                if (fieldValue.length > length){
+                    evt.preventDefault();
+                    startPos = text.search(new RegExp(fieldValue));
+                    textAreaElement.setSelectionRange(startPos, startPos + fieldValue.length)
+                    textAreaElement.focus();
+                    var div = document.createElement("div");
+                    div.className = "alert alert-danger mt-3 mb-3";
+                    div.textContent = `column '${validatedField}': '${fieldValue}' is too long (maximum ${length} characters)`;
+                    var formElement = document.getElementById("form");
+                    formElement.insertBefore(div, formElement.firstChild);
+                };
+            };
+        };
+    };
+</script>
+{% endmacro %}

--- a/app/templates/main/corpus_new.html
+++ b/app/templates/main/corpus_new.html
@@ -1,8 +1,10 @@
 {% extends 'layouts/base.html' %}
 {% import 'macros/upload_text.html' as upload_text %}
+{% import 'macros/validate_length.html' as validateLength %}
 
 {% block content %}
-<form method="POST" action="{{url_for("main.corpus_new")}}">
+    <form method="POST" action="{{url_for("main.corpus_new")}}" id="form">
+    {{ validateLength.validateLength("tokens", {0: 64}) }}
     <h1>Create a new corpus</h1>
     <fieldset class="form-fieldset">
         <legend>Metadata</legend>

--- a/app/templates/main/corpus_new.html
+++ b/app/templates/main/corpus_new.html
@@ -34,7 +34,7 @@
         <legend>Data</legend>
         {{ upload_text.upload_text("tokens") }}
         <div class="form-group">
-            <label for="tokens">Tokens (as TSV content)</label>
+            <label for="tokens" id="tokensLabel">Tokens (as TSV content)</label>
             <small id="tsvHelp" class="form-text text-muted">The TSV should at least have the headers : form, lemma, POS, morph</small>
             <small>Example :</small>
             <pre>form	lemma	POS	morph

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,8 +1,32 @@
 from .pagination import int_or
 from .tsv import StringDictReader
 from .forms import string_to_none
+from typing import Dict
 
 
 class PyrrhaError(Exception):
     """Raised when errors specific to this application occur."""
     pass
+
+
+class ValidationError(PyrrhaError):
+    """Raised when constraints on data types are not respected."""
+    pass
+
+
+def validate_length(k: str, v: str, lengths: Dict[str, int]):
+    """Enforce length constraints on data types to ensure
+    portability of the database schema.
+
+    SQLite does not enforce length constraints on data types.
+
+    :param str k: column name
+    :param str v: column value
+    :param dict lengths: mapping of column names to length constraints
+
+    :raises ValidationError: when length constraint is not respected
+    """
+    if k in lengths and len(v) > lengths[k]:
+        raise ValidationError(
+            f"column '{k}': '{v}' is too long (maximum {lengths[k]} characters)"
+        )

--- a/tests/test_models/test_word_token.py
+++ b/tests/test_models/test_word_token.py
@@ -1,5 +1,8 @@
 from .base import TestModels
 from app.models import WordToken
+from app.utils import ValidationError
+import random
+import string
 
 
 class TestWordToken(TestModels):
@@ -15,3 +18,27 @@ class TestWordToken(TestModels):
             "2\tor\tor4\t_\tDEGRE=-\r\n"
             "3\tescoutez\tescouter\t_\tMODE=imp|PERS.=2|NOMB.=p\r\n"
         )
+
+    def test_add_batch_invalid(self):
+        """Test adding a batch of tokens.
+
+        Trying: one token violates length constraint
+        Expecting: ValidationError
+        """
+        form = "".join(
+            string.ascii_letters[random.randint(0, len(string.ascii_letters)-1)] for i in range(100)
+        )
+        with self.assertRaises(ValidationError):
+            WordToken.add_batch(0, [{"form": form}])
+
+    def test_add_batch_valid(self):
+        """Test adding a batch of tokens.
+
+        Trying: one token respecting length constraint
+        Expecting: number of tokens is returned
+        """
+        form = "".join(
+            string.ascii_letters[random.randint(0, len(string.ascii_letters)-1)]
+            for i in range(64)
+        )
+        self.assertEqual(WordToken.add_batch(0, [{"form": form}]), 1)

--- a/tests/test_selenium/test_corpus_init.py
+++ b/tests/test_selenium/test_corpus_init.py
@@ -574,7 +574,7 @@ soit	estre1	VERcjg	MODE=sub|TEMPS=pst|PERS.=3|NOMB.=s""")
         self.driver.implicitly_wait(15)
         self.assertEqual(
             self.driver.find_elements_by_css_selector(".alert.alert-danger")[0].text.strip(),
-            f"column 'form': '{invalid}' is too long (maximum 64 characters)"
+            f"ln. 2, column 'form': '{invalid}' is too long (maximum 64 characters)"
         )
 
     def test_registration_without_field_length_violation(self):


### PR DESCRIPTION
Hi,

I'm opening the pull request as a WIP for the back end part first, I wanted to confirm that this is what you had in mind, and if so, for which fields the validation should be done. Also, I was wondering if the same validation shouldn't be done for any other field having a length restriction in the database schema which is set using user input, such as the corpus name.
