### PR TITLE
Add edit user cli subcommand edit-user

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -36,15 +36,25 @@ def make_cli():
         app = create_app(config)
 
     @click.command("edit-user")
-    @click.argument("user_id")
+    @click.argument("user_id_or_email")
     @click.option("--confirm-mail", "is_confirmed", is_flag=True,
                   help="Confirm mail address.")
     @click.option("--role", "role", type=click.Choice(['User', 'Administrator'], case_sensitive=False), required=False,
                   help="Set role.")
-    def edit_user(user_id, is_confirmed=False, role=None):
-        """Edits a user
+    def edit_user(user_id_or_email, is_confirmed=False, role=None):
+        """Edits a user by id or email
         """
         with app.app_context():
+            try:
+                int(user_id_or_email)
+                user_id = user_id_or_email
+            except ValueError:
+                lookup = User.query.filter(User.email == user_id_or_email).first()
+                user_id = lookup.id if lookup else None
+
+            if not user_id:
+                click.echo(f"User with email '{user_id_or_email}' not found.")
+
             user = User.query.filter(User.id == user_id).first()
             if not user:
                 click.echo(f"User with id '{user_id}' not found.")

--- a/app/cli.py
+++ b/app/cli.py
@@ -40,7 +40,7 @@ def make_cli():
     @click.option("--confirm-mail", "is_confirmed", is_flag=True,
                   help="Confirm mail address.")
     @click.option("--role", "role", type=click.Choice(['User', 'Administrator'], case_sensitive=False), required=False,
-                  help="Set role. Default: User.")
+                  help="Set role.")
     def edit_user(user_id, is_confirmed=False, role=None):
         """Edits a user
         """

--- a/app/cli.py
+++ b/app/cli.py
@@ -42,7 +42,7 @@ def make_cli():
     @click.option("--role", "role", type=click.Choice(['User', 'Administrator'], case_sensitive=False), required=False,
                   help="Set role. Default: User.")
     def edit_user(user_id, is_confirmed=False, role=None):
-        """Edits a registered user
+        """Edits a user
         """
         with app.app_context():
             user = User.query.filter(User.id == user_id).first()

--- a/tests/test_cli/test_generic.py
+++ b/tests/test_cli/test_generic.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 
 from app import db, create_app
 from app.cli import make_cli
-from app.models import Corpus, ControlLists
+from app.models import Corpus, ControlLists, Role, User
 
 
 class TestGenericScript(TestCase):
@@ -34,6 +34,79 @@ class TestGenericScript(TestCase):
 
     def invoke(self, commands):
         return self.runner.invoke(self.cli, ["--config", "test"] + commands)
+
+    def test_edit_user_should_set_role_to_administrator(self):
+        """Test that user has role administrator"""
+
+        TEST_USER_ID = 1
+
+        with self.app.app_context():
+            db.create_all()
+            Role.add_default_roles()
+            db.session.commit()
+        
+        with self.app.app_context():
+            role_user = Role.query.filter(Role.name == 'User').first()
+            unconfirmed_user = User(
+                id=TEST_USER_ID,
+                first_name='test',
+                last_name='test',
+                email='test@example.org',
+                password='password',
+                confirmed=False,
+                role=role_user,
+            )
+            db.session.add(unconfirmed_user)
+            db.session.commit()
+
+        with self.app.app_context():
+            role_user = Role.query.filter(Role.name == 'User').first()
+            self.assertIsNotNone(role_user)
+            user = User.query.get(TEST_USER_ID)
+            self.assertEqual(user.role_id, role_user.id)
+        
+        response = self.invoke(["edit-user", f"{TEST_USER_ID}", "--role", "Administrator"])
+
+        with self.app.app_context():
+            role_administrator = Role.query.filter(Role.name == 'Administrator').first()
+            self.assertIsNotNone(role_administrator)
+            user = User.query.get(TEST_USER_ID)
+            self.assertEqual(user.role_id, role_administrator.id)
+
+
+    def test_edit_user_should_confirm_user(self):
+        """Test that user is confirmed"""
+
+        TEST_USER_ID = 1
+
+        with self.app.app_context():
+            db.create_all()
+            Role.add_default_roles()
+            db.session.commit()
+        
+        with self.app.app_context():
+            role_user = Role.query.filter(Role.name == 'User').first()
+            unconfirmed_user = User(
+                id=TEST_USER_ID,
+                first_name='test',
+                last_name='test',
+                email='test@example.org',
+                password='password',
+                confirmed=False,
+                role=role_user,
+            )
+            db.session.add(unconfirmed_user)
+            db.session.commit()
+
+        with self.app.app_context():
+            user = User.query.get(TEST_USER_ID)
+            self.assertFalse(user.confirmed)
+
+        response = self.invoke(["edit-user", f"{TEST_USER_ID}", "--confirm-mail"])
+
+        with self.app.app_context():
+            user = User.query.get(TEST_USER_ID)
+            self.assertTrue(user.confirmed)
 
     def test_db_create(self):
         """ Test that db is created """

--- a/tests/test_cli/test_generic.py
+++ b/tests/test_cli/test_generic.py
@@ -35,6 +35,45 @@ class TestGenericScript(TestCase):
     def invoke(self, commands):
         return self.runner.invoke(self.cli, ["--config", "test"] + commands)
 
+    def test_edit_user_should_get_user_by_email(self):
+        """Test that user gets identified by email"""
+
+        TEST_USER_ID = 1
+        TEST_USER_EMAIL = 'test@example.org'
+
+        with self.app.app_context():
+            db.create_all()
+            Role.add_default_roles()
+            db.session.commit()
+        
+        with self.app.app_context():
+            role_user = Role.query.filter(Role.name == 'User').first()
+            unconfirmed_user = User(
+                id=TEST_USER_ID,
+                first_name='test',
+                last_name='test',
+                email=TEST_USER_EMAIL,
+                password='password',
+                confirmed=False,
+                role=role_user,
+            )
+            db.session.add(unconfirmed_user)
+            db.session.commit()
+
+        with self.app.app_context():
+            role_user = Role.query.filter(Role.name == 'User').first()
+            self.assertIsNotNone(role_user)
+            user = User.query.get(TEST_USER_ID)
+            self.assertEqual(user.role_id, role_user.id)
+        
+        response = self.invoke(["edit-user", f"{TEST_USER_EMAIL}", "--role", "Administrator"])
+
+        with self.app.app_context():
+            role_administrator = Role.query.filter(Role.name == 'Administrator').first()
+            self.assertIsNotNone(role_administrator)
+            user = User.query.get(TEST_USER_ID)
+            self.assertEqual(user.role_id, role_administrator.id)
+
     def test_edit_user_should_set_role_to_administrator(self):
         """Test that user has role administrator"""
 


### PR DESCRIPTION
Adds the subcommand `edit-user`.

```
Usage: manage.py edit-user [OPTIONS] USER_ID_OR_EMAIL

  Edits a user by id or email

Options:
  --confirm-mail               Confirm mail address.
  --role [User|Administrator]  Set role.
  --help                       Show this message and exit.
```

* Changed `--set-admin` to `--role`. It may be desirable to remove the admin role from users.
* Changed `--activate` to `--confirm-mail`. Is more verbose and tells what the action will do.

A call to _confirm_ the mail address and make a user a _admin_ would look like this (someone may run the options separately):

```
python manage.py edit-user 2 --confirm-mail --role=Administrator
python manage.py edit-user hello@example.org --confirm-mail --role=Administrator
```

See: #167 .