### PR TITLE
always display "Propose changes" on control list menu bar

### DIFF
--- a/app/templates/control_lists/macros.html
+++ b/app/templates/control_lists/macros.html
@@ -16,9 +16,7 @@
     </ul>
     Others
     <ul class="nav flex-column">
-      {% if not control_list.can_edit() %}
       <li class="nav-item"><a class="nav-link" href="{{url_for("control_lists_bp.contact", control_list_id=control_list.id)}}"><i class="fa fa-envelope"></i> Propose changes</a></li>
-      {% endif %}
       {%  if control_list.can_edit() and not current_user.is_admin() %}
       <li class="nav-item"><a class="nav-link" href="{{url_for("control_lists_bp.propose_as_public", control_list_id=control_list.id)}}"><i class="fa fa-share-alt"></i> Make public</a></li>
       {% endif %}

--- a/tests/test_selenium/test_control_lists.py
+++ b/tests/test_selenium/test_control_lists.py
@@ -37,8 +37,17 @@ class TestUpdateControlList(TestBase):
         links = self.driver.find_element_by_id("left-menu").find_elements_by_tag_name("a")
         self.assertEqual(
             sorted([link.text for link in links]),
-            sorted(["Edit informations", "Guidelines",
-                    'Lemma', 'Make public', 'Morphologies', 'POS', 'Wauchier', 'Rename']),
+            sorted([
+                "Edit informations",
+                "Guidelines",
+                'Lemma',
+                'Make public',
+                'Morphologies',
+                'POS',
+                'Propose changes',
+                'Wauchier',
+                'Rename'
+            ]),
             "Full rewrite are limited to control lists users"
         )
 


### PR DESCRIPTION
https://github.com/hipster-philology/pyrrha/issues/135#issuecomment-735667231

We now always display "Propose changes" link on control list pages.

close: https://github.com/hipster-philology/pyrrha/issues/135