### PR TITLE
don't allow to disable Lemma and POS and Morph

### DIFF
--- a/app/main/views/corpus.py
+++ b/app/main/views/corpus.py
@@ -77,6 +77,16 @@ def corpus_new():
                 column.hidden = bool(
                     request.form.get(f"{column.heading.lower()}Column", "")
                 )
+            if (
+                "lemmaColumn" in request.form
+                and "posColumn" in request.form
+                and "morphColumn" in request.form
+            ):
+                flash(
+                    "You can't disable Lemma and POS and Morph. Keep at least one of them.",
+                    category="error"
+                )
+                return error()
 
             if request.form.get("control_list") == "reuse":
                 tokens = read_input_tokens(request.form.get("tsv"))

--- a/app/models/corpus.py
+++ b/app/models/corpus.py
@@ -449,6 +449,10 @@ class Corpus(db.Model):
 
         :param dict columns: column states (hidden or not hidden)
         """
+        if columns.get("lemma") and columns.get("pos") and columns.get("morph"):
+            raise PreferencesUpdateError(
+                "You can't disable Lemma and POS and Morph. Keep at least one of them."
+            )
         for column in self.columns:
             try:
                 column.hidden = columns.get(column.heading.lower(), False)


### PR DESCRIPTION
close: https://github.com/hipster-philology/pyrrha/issues/239

This pull request allows to prevent disabling of Lemma and POS and Morph columns at same time, at corpus creation and in the preference panel.