### PR TITLE
Remove unwanted apostrophe

### DIFF
--- a/app/templates/main/tokens_similar_to_record.html
+++ b/app/templates/main/tokens_similar_to_record.html
@@ -57,7 +57,7 @@
     </tbody>
 </table>
 
-<h2>{{ _('Similar matching:') }}' {{record.similar_remaining}}</h2>
+<h2>{{ _('Similar matching:') }} {{record.similar_remaining}}</h2>
 <div class="main">
 {{ tokens_macros.table(tokens, corpus=corpus, changed=changed, editable=True, checkbox=True, record=record, link_back=True) }}
 </div>


### PR DESCRIPTION
This PR removes a typo from the page "Similar matching": unwanted apostrophe

![Capture d’écran du 2024-05-31 15-12-14](https://github.com/hipster-philology/pyrrha/assets/74190212/57e37157-a035-4f36-bfc3-e9aa9ef756c4)
